### PR TITLE
Prefs getter

### DIFF
--- a/src/Preferences/index.js
+++ b/src/Preferences/index.js
@@ -114,9 +114,18 @@ async function storeGlobalPrefs(prefs) {
 // return local scope to this origin
 async function getPrefs() {
   // grab the current prefs
-  const localPrefs = await retrieveLocalPrefs();
-  const globalPrefs = await retriveGlobalPrefs();
+  let localPrefs = await retrieveLocalPrefs();
+  let globalPrefs = await retriveGlobalPrefs();
   const origin = await getOrigin();
+
+  if (localPrefs == null) {
+    localPrefs = {};
+  }
+
+  // just in case their missing a default prefs
+  // be sure to pepper the default prefs
+  localPrefs[origin] = { ...defaultPrefs, ...localPrefs[origin] };
+  globalPrefs = { ...defaultPrefs, ...globalPrefs };
 
   const currentScope = localPrefs[origin].scope;
 

--- a/src/Preferences/index.js
+++ b/src/Preferences/index.js
@@ -44,7 +44,9 @@ function init(config) {
   // subscribers but it be easy
   // to expose another api to add
   // to subscriber if needed
-  subscribers.push(config.subscribe);
+  if (config.subscribe) {
+    subscribers.push(config.subscribe);
+  }
   if (config.onStartup) {
     startupSubscribers.push(config.onStartup);
   }
@@ -55,6 +57,7 @@ function init(config) {
   return {
     start,
     setPrefs,
+    getPrefs,
     defaultPrefs: () => defaultPrefs,
   };
 }
@@ -103,6 +106,23 @@ async function storeLocalPrefs(prefs) {
 // Store global preferences into storage
 async function storeGlobalPrefs(prefs) {
   return storePrefs(prefs, 'global');
+}
+
+// get the current Preferences based on the current
+// scope so if the user current setting is global
+// it will return the global prefs, otherwise
+// return local scope to this origin
+async function getPrefs() {
+  // grab the current prefs
+  const localPrefs = await retrieveLocalPrefs();
+  const globalPrefs = await retriveGlobalPrefs();
+  const origin = await getOrigin();
+
+  const currentScope = localPrefs[origin].scope;
+
+  return (currentScope === 'local'
+    ? localPrefs[origin]
+    : globalPrefs);
 }
 
 // setPrefs updates the preferences in storage


### PR DESCRIPTION
Added a prefs getter to get the current preferences which is either "local" or "global" which ever is selected by the user on the current tab. 

Example, if you want to get the current preference 
```javascript
// Initialize Preferences with a getOrigin function that "knows how to get the origin of the current tab
// and it will return an object to set and get preferences, 
// one of its methods are getPrefs, which you can 
// use to get the current preferences, so if the user is currently
// using the global prefs, it will return that, and if they are using
// "per site", it will return that preference of that site
const { getPrefs } = Preferences.init({
    getOrigin: async () => TabHelper.getActiveTab(TabHelper.getOrigin),
});

const currentPrefs = await getPrefs()
// {
//  saccadesInterval: 0,
//  lineHeight: 1,
//  fixationStrength: 2,
//  scope: 'global',
//  onPageLoad: false,
// }
```